### PR TITLE
Improved Surfaces

### DIFF
--- a/project/addons/terrain_3d/editor/components/surface_list.gd
+++ b/project/addons/terrain_3d/editor/components/surface_list.gd
@@ -174,7 +174,9 @@ class ListEntry extends VBoxContainer:
 		name_label.add_theme_color_override("font_shadow_color", Color.BLACK)
 		name_label.add_theme_constant_override("shadow_offset_x", 1)
 		name_label.add_theme_constant_override("shadow_offset_y", 1)
-		name_label.add_theme_font_size_override("font_size", 16)
+		name_label.add_theme_font_size_override("font_size", 15)
+		name_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		name_label.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
 		name_label.text = "Add New"
 		
 		
@@ -191,6 +193,8 @@ class ListEntry extends VBoxContainer:
 					var texture: Texture2D = resource.get_albedo_texture()
 					if texture:
 						draw_texture_rect(texture, rect, false)
+						texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST_WITH_MIPMAPS
+				name_label.add_theme_font_size_override("font_size", 4 + rect.size.x/10)
 				if drop_data:
 					draw_style_box(focus, rect)
 				if is_hovered:

--- a/project/addons/terrain_3d/editor/components/surface_list.gd
+++ b/project/addons/terrain_3d/editor/components/surface_list.gd
@@ -1,13 +1,14 @@
 extends PanelContainer
 
+
 signal resource_changed(resource: Resource, index: int)
 signal resource_inspected(resource: Resource)
 signal resource_selected
 
 var list: ListContainer
 var entries: Array[ListEntry]
-
 var selected_index: int = 0
+
 
 func _init() -> void:
 	list = ListContainer.new()
@@ -30,57 +31,79 @@ func _init() -> void:
 	add_child(root)
 	
 	set_custom_minimum_size(Vector2(256, 448))
+
 	
 func _ready() -> void:
 	get_child(0).get_child(0).set("theme_override_styles/normal", get_theme_stylebox("bg", "EditorInspectorCategory"))
 	get_child(0).get_child(0).set("theme_override_fonts/font", get_theme_font("bold", "EditorFonts"))
 	get_child(0).get_child(0).set("theme_override_font_sizes/font_size",get_theme_font_size("bold_size", "EditorFonts"))
 	set("theme_override_styles/panel", get_theme_stylebox("panel", "Panel"))
-	
-func notify_resource_changed(resource: Resource, index: int) -> void:
-	if !resource:
-		selected_index = clamp(selected_index, 0, entries.size() - 3)
-	
-	emit_signal("resource_changed", resource, index)
-	
-func notify_resource_inspected(resource: Resource):
-	emit_signal("resource_inspected", resource)
 
-func set_selected_index(index: int):
-	selected_index = index
-	emit_signal("resource_selected")
-	
-	for i in entries.size():
-		var entry: ListEntry = entries[i]
-		entry.set_selected(i == selected_index)
-	
-func get_selected_index():
-	return selected_index
+
+func clear() -> void:
+	for i in entries:
+		i.get_parent().remove_child(i)
+		i.queue_free()
+	entries.clear()
+
 
 func add_item(resource: Resource = null) -> void:
 	var entry: ListEntry = ListEntry.new()
 	var index: int = entries.size()
 	
 	entry.set_edited_resource(resource)
-	entry.connect("changed", notify_resource_changed.bind(index))
-	entry.connect("inspected", notify_resource_inspected)
-	entry.connect("selected", set_selected_index.bind(index))
+	entry.selected.connect(set_selected_index.bind(index))
+	entry.inspected.connect(notify_resource_inspected)
+	entry.changed.connect(notify_resource_changed.bind(index))
 	
 	if resource:
 		entry.set_selected(index == selected_index)
+		if not resource.id_changed.is_connected(set_selected_after_swap):
+			resource.id_changed.connect(set_selected_after_swap)
 	
 	list.add_child(entry)
 	entries.push_back(entry)
+
+
+func set_selected_after_swap(old_index: int, new_index: int) -> void:
+	set_selected_index(clamp(new_index, 0, entries.size() - 2))
+
+
+func set_selected_index(index: int) -> void:
+	selected_index = index
+	emit_signal("resource_selected")
 	
-func clear():
-	for i in entries:
-		i.free()
-	entries.clear()
+	for i in entries.size():
+		var entry: ListEntry = entries[i]
+		entry.set_selected(i == selected_index)
+
+
+func get_selected_index() -> int:
+	return selected_index
+
+
+func notify_resource_inspected(resource: Resource) -> void:
+	emit_signal("resource_inspected", resource)
+
+
+func notify_resource_changed(resource: Resource, index: int) -> void:
+	emit_signal("resource_changed", resource, index)
+	if !resource:
+		var last_offset: int = 2
+		if index == entries.size()-2:
+			last_offset = 3
+		selected_index = clamp(selected_index, 0, entries.size() - last_offset)	
+
+
+##############################################################
+## class ListContainer
+##############################################################
+
 	
 class ListContainer extends Container:
 	var height: float = 0
 	
-	func _notification(what):
+	func _notification(what) -> void:
 		if what == NOTIFICATION_SORT_CHILDREN:
 			height = 0
 			var index: int = 0
@@ -93,8 +116,14 @@ class ListContainer extends Container:
 					height = max(height, c.position.y + width)
 					index += 1
 					
-	func _get_minimum_size():
+	func _get_minimum_size() -> Vector2:
 		return Vector2(0, height)
+
+
+##############################################################
+## class ListEntry
+##############################################################
+
 
 class ListEntry extends VBoxContainer:
 	signal selected()
@@ -106,35 +135,50 @@ class ListEntry extends VBoxContainer:
 	var is_hovered: bool = false
 	var is_selected: bool = false
 	
-	var button_close: TextureButton
+	var button_clear: TextureButton
 	var button_edit: TextureButton
+	var name_label: Label
 	
 	@onready var add_icon: Texture2D = get_theme_icon("Add", "EditorIcons")
-	@onready var close_icon: Texture2D = get_theme_icon("Close", "EditorIcons")
+	@onready var clear_icon: Texture2D = get_theme_icon("Close", "EditorIcons")
 	@onready var edit_icon: Texture2D = get_theme_icon("Edit", "EditorIcons")
 	@onready var background: StyleBox = get_theme_stylebox("pressed", "Button")
 	@onready var focus: StyleBox = get_theme_stylebox("focus", "Button")
 	
-	func _ready():
+
+	func _ready() -> void:
 		var icon_size: Vector2 = Vector2(12, 12)
 		
-		button_close = TextureButton.new()
-		button_close.set_texture_normal(close_icon)
-		button_close.set_custom_minimum_size(icon_size)
-		button_close.set_h_size_flags(Control.SIZE_SHRINK_END)
-		button_close.set_visible(resource != null)
-		button_close.connect("pressed", close)
-		add_child(button_close)
+		button_clear = TextureButton.new()
+		button_clear.set_texture_normal(clear_icon)
+		button_clear.set_custom_minimum_size(icon_size)
+		button_clear.set_h_size_flags(Control.SIZE_SHRINK_END)
+		button_clear.set_visible(resource != null)
+		button_clear.pressed.connect(clear)
+		add_child(button_clear)
 		
 		button_edit = TextureButton.new()
 		button_edit.set_texture_normal(edit_icon)
 		button_edit.set_custom_minimum_size(icon_size)
 		button_edit.set_h_size_flags(Control.SIZE_SHRINK_END)
 		button_edit.set_visible(resource != null)
-		button_edit.connect("pressed", edit)
+		button_edit.pressed.connect(edit)
 		add_child(button_edit)
 		
-	func _notification(what):
+		name_label = Label.new()
+		add_child(name_label, true)
+		name_label.visible = false
+		name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		name_label.vertical_alignment = VERTICAL_ALIGNMENT_BOTTOM
+		name_label.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		name_label.add_theme_color_override("font_shadow_color", Color.BLACK)
+		name_label.add_theme_constant_override("shadow_offset_x", 1)
+		name_label.add_theme_constant_override("shadow_offset_y", 1)
+		name_label.add_theme_font_size_override("font_size", 16)
+		name_label.text = "Add New"
+		
+		
+	func _notification(what) -> void:
 		match what:
 			NOTIFICATION_DRAW:
 				var rect: Rect2 = Rect2(Vector2.ZERO, get_size())
@@ -142,48 +186,57 @@ class ListEntry extends VBoxContainer:
 					draw_style_box(background, rect)
 					draw_texture(add_icon, (get_size() / 2) - (add_icon.get_size() / 2))
 				else:
+					name_label.text = resource.get_name()
+					self_modulate = resource.get_albedo()
 					var texture: Texture2D = resource.get_albedo_texture()
 					if texture:
 						draw_texture_rect(texture, rect, false)
-					modulate = resource.get_albedo()
 				if drop_data:
 					draw_style_box(focus, rect)
 				if is_hovered:
 					draw_rect(rect, Color(1,1,1,0.2))
 				if is_selected:
 					draw_style_box(focus, rect)
-				
 			NOTIFICATION_MOUSE_ENTER:
 				is_hovered = true
+				name_label.visible = true
 				queue_redraw()
 			NOTIFICATION_MOUSE_EXIT:
 				is_hovered = false
+				name_label.visible = false
 				drop_data = false
 				queue_redraw()
+
 	
-	func _gui_input(event: InputEvent):
+	func _gui_input(event: InputEvent) -> void:
 		if event is InputEventMouseButton:
 			if event.is_pressed():
 				match event.get_button_index():
 					MOUSE_BUTTON_LEFT:
+						# If `Add new` is clicked
 						if !resource:
 							set_edited_resource(Terrain3DSurface.new(), false)
+							edit()
 						else:
 							emit_signal("selected")
 					MOUSE_BUTTON_RIGHT:
-						edit()
+						if resource:
+							edit()
 					MOUSE_BUTTON_MIDDLE:
-						close()
-			
-	func _can_drop_data(at_position: Vector2, data: Variant):
+						if resource:
+							clear()
+
+
+	func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
 		drop_data = false
 		if typeof(data) == TYPE_DICTIONARY:
 			if data.files.size() == 1:
 				queue_redraw()
 				drop_data = true
 		return drop_data
+
 		
-	func _drop_data(at_position: Vector2, data: Variant):
+	func _drop_data(at_position: Vector2, data: Variant) -> void:
 		if typeof(data) == TYPE_DICTIONARY:
 			var res: Resource = load(data.files[0])
 			if res is Terrain3DSurface:
@@ -192,34 +245,36 @@ class ListEntry extends VBoxContainer:
 				var surf: Terrain3DSurface = Terrain3DSurface.new()
 				surf.set_albedo_texture(res)
 				set_edited_resource(surf, false)
+
 	
-	func set_edited_resource(res: Terrain3DSurface, no_signal: bool = true):
+	func set_edited_resource(res: Terrain3DSurface, no_signal: bool = true) -> void:
 		resource = res
 		if resource:
-			var text: String = resource.get_path()
-			if text.is_empty():
-				text = "New Surface"
-			set_tooltip_text(text)
 			resource.value_changed.connect(_on_surface_changed)
 			resource.texture_changed.connect(_on_surface_changed)
 		
-		if button_close:
-			button_close.set_visible(resource != null)
+		if button_clear:
+			button_clear.set_visible(resource != null)
 			
 		queue_redraw()
 		if !no_signal:
 			emit_signal("changed", resource)
 
+
 	func _on_surface_changed() -> void:
 		emit_signal("changed", resource)
 
-	func set_selected(value: bool):
+
+	func set_selected(value: bool) -> void:
 		is_selected = value
 		queue_redraw()
-			
-	func close():
+
+
+	func clear() -> void:
 		if resource:
 			set_edited_resource(null, false)
+
 	
-	func edit():
+	func edit() -> void:
+		emit_signal("selected")
 		emit_signal("inspected", resource)

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -67,6 +67,8 @@ private:
 	static const int REGION_MAP_SIZE = 16;
 	static inline const Vector2i REGION_MAP_VSIZE = Vector2i(REGION_MAP_SIZE, REGION_MAP_SIZE);
 
+	static const int SURFACE_MAX_SIZE = 32;
+
 	class Generated {
 	private:
 		RID _rid = RID();
@@ -219,7 +221,7 @@ public:
 
 	// Materials
 
-	void set_surface(const Ref<Terrain3DSurface> &p_material, int p_index);
+	void set_surface(int p_index, const Ref<Terrain3DSurface> &p_material);
 	Ref<Terrain3DSurface> get_surface(int p_index) const { return _surfaces[p_index]; }
 	void set_surfaces(const TypedArray<Terrain3DSurface> &p_surfaces);
 	TypedArray<Terrain3DSurface> get_surfaces() const { return _surfaces; }
@@ -265,6 +267,8 @@ public:
 
 	// Regenerate data
 	// Workaround until callable_mp is implemented
+	// https://github.com/godotengine/godot-cpp/pull/1155
+	void _swap_surfaces(int p_old_id, int p_new_id);
 	void update_surface_textures();
 	void update_surface_values();
 	void force_update_maps(MapType p_map = TYPE_MAX);

--- a/src/terrain_3d_surface.cpp
+++ b/src/terrain_3d_surface.cpp
@@ -37,32 +37,53 @@ Terrain3DSurface::Terrain3DSurface() {
 Terrain3DSurface::~Terrain3DSurface() {
 }
 
+void Terrain3DSurface::clear() {
+	_data._name = "New Texture";
+	_data._surface_id = 0;
+	_data._albedo = Color(1.0, 1.0, 1.0, 1.0);
+	_data._albedo_texture.unref();
+	_data._normal_texture.unref();
+	_data._uv_scale = 0.1f;
+	_data._uv_rotation = 0.0f;
+}
+
+void Terrain3DSurface::set_name(String p_name) {
+	_data._name = p_name;
+	emit_signal("value_changed");
+}
+
+void Terrain3DSurface::set_surface_id(int p_new_id) {
+	int old_id = _data._surface_id;
+	_data._surface_id = p_new_id;
+	emit_signal("id_changed", old_id, p_new_id);
+}
+
 void Terrain3DSurface::set_albedo(Color p_color) {
-	_albedo = p_color;
+	_data._albedo = p_color;
 	emit_signal("value_changed");
 }
 
 void Terrain3DSurface::set_albedo_texture(const Ref<Texture2D> &p_texture) {
 	if (_texture_is_valid(p_texture)) {
-		_albedo_texture = p_texture;
+		_data._albedo_texture = p_texture;
 		emit_signal("texture_changed");
 	}
 }
 
 void Terrain3DSurface::set_normal_texture(const Ref<Texture2D> &p_texture) {
 	if (_texture_is_valid(p_texture)) {
-		_normal_texture = p_texture;
+		_data._normal_texture = p_texture;
 		emit_signal("texture_changed");
 	}
 }
 
 void Terrain3DSurface::set_uv_scale(float p_scale) {
-	_uv_scale = p_scale;
+	_data._uv_scale = p_scale;
 	emit_signal("value_changed");
 }
 
 void Terrain3DSurface::set_uv_rotation(float p_rotation) {
-	_uv_rotation = CLAMP(p_rotation, 0.0f, 1.0f);
+	_data._uv_rotation = CLAMP(p_rotation, 0.0f, 1.0f);
 	emit_signal("value_changed");
 }
 
@@ -71,9 +92,15 @@ void Terrain3DSurface::set_uv_rotation(float p_rotation) {
 ///////////////////////////
 
 void Terrain3DSurface::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("id_changed"));
 	ADD_SIGNAL(MethodInfo("texture_changed"));
 	ADD_SIGNAL(MethodInfo("value_changed"));
 
+	ClassDB::bind_method(D_METHOD("clear"), &Terrain3DSurface::clear);
+	ClassDB::bind_method(D_METHOD("set_name", "name"), &Terrain3DSurface::set_name);
+	ClassDB::bind_method(D_METHOD("get_name"), &Terrain3DSurface::get_name);
+	ClassDB::bind_method(D_METHOD("set_surface_id", "id"), &Terrain3DSurface::set_surface_id);
+	ClassDB::bind_method(D_METHOD("get_surface_id"), &Terrain3DSurface::get_surface_id);
 	ClassDB::bind_method(D_METHOD("set_albedo", "color"), &Terrain3DSurface::set_albedo);
 	ClassDB::bind_method(D_METHOD("get_albedo"), &Terrain3DSurface::get_albedo);
 	ClassDB::bind_method(D_METHOD("set_albedo_texture", "texture"), &Terrain3DSurface::set_albedo_texture);
@@ -85,6 +112,8 @@ void Terrain3DSurface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_uv_rotation", "scale"), &Terrain3DSurface::set_uv_rotation);
 	ClassDB::bind_method(D_METHOD("get_uv_rotation"), &Terrain3DSurface::get_uv_rotation);
 
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "name", PROPERTY_HINT_NONE), "set_name", "get_name");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "surface_id", PROPERTY_HINT_NONE), "set_surface_id", "get_surface_id");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "albedo", PROPERTY_HINT_COLOR_NO_ALPHA), "set_albedo", "get_albedo");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "albedo_texture", PROPERTY_HINT_RESOURCE_TYPE, "ImageTexture,CompressedTexture2D"), "set_albedo_texture", "get_albedo_texture");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "normal_texture", PROPERTY_HINT_RESOURCE_TYPE, "ImageTexture,CompressedTexture2D"), "set_normal_texture", "get_normal_texture");

--- a/src/terrain_3d_surface.h
+++ b/src/terrain_3d_surface.h
@@ -15,11 +15,15 @@ class Terrain3DSurface : public Resource {
 private:
 	GDCLASS(Terrain3DSurface, Resource);
 
-	Color _albedo = Color(1.0, 1.0, 1.0, 1.0);
-	Ref<Texture2D> _albedo_texture;
-	Ref<Texture2D> _normal_texture;
-	float _uv_scale = 0.1f;
-	float _uv_rotation = 0.0f;
+	struct Settings {
+		String _name = "New Texture";
+		int _surface_id = 0;
+		Color _albedo = Color(1.0, 1.0, 1.0, 1.0);
+		Ref<Texture2D> _albedo_texture;
+		Ref<Texture2D> _normal_texture;
+		float _uv_scale = 0.1f;
+		float _uv_rotation = 0.0f;
+	} _data;
 
 	bool _texture_is_valid(const Ref<Texture2D> &p_texture) const;
 
@@ -27,20 +31,30 @@ public:
 	Terrain3DSurface();
 	~Terrain3DSurface();
 
+	// Edit data directly to avoid signal emitting recursion
+	Settings *get_data() { return &_data; }
+	void clear();
+
+	void set_name(String p_name);
+	String get_name() const { return _data._name; }
+
+	void set_surface_id(int p_new_id);
+	int get_surface_id() const { return _data._surface_id; }
+
 	void set_albedo(Color p_color);
-	Color get_albedo() const { return _albedo; }
+	Color get_albedo() const { return _data._albedo; }
 
 	void set_albedo_texture(const Ref<Texture2D> &p_texture);
-	Ref<Texture2D> get_albedo_texture() const { return _albedo_texture; }
+	Ref<Texture2D> get_albedo_texture() const { return _data._albedo_texture; }
 
 	void set_normal_texture(const Ref<Texture2D> &p_texture);
-	Ref<Texture2D> get_normal_texture() const { return _normal_texture; }
+	Ref<Texture2D> get_normal_texture() const { return _data._normal_texture; }
 
 	void set_uv_scale(float p_scale);
-	float get_uv_scale() const { return _uv_scale; }
+	float get_uv_scale() const { return _data._uv_scale; }
 
 	void set_uv_rotation(float p_rotation);
-	float get_uv_rotation() const { return _uv_rotation; }
+	float get_uv_rotation() const { return _data._uv_rotation; }
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Goals:
* Ensure surface ids are stable and do not change when adding/deleting surfaces or saving/loading storage.
* Allow the user to change surface ids, moving painted terrain from one texture to another.
* Improve user workflow in selecting and editing surfaces

Implemented:
* When surfaces are added in bulk they are audited to ensure surface ids are unique and in range
* Surfaces can no longer be removed in the middle of the array. Clicking the X blanks them. They can be removed at the end.
* Displays surface id, which can be changed, moving painted terrain to another texture
* Added editable surface names that display in the list on hover, removing tooltip
* Changes to surface redraws thumbnail instantly
* Many updates to flow, such as new surface starts editing in inspector right away, inspector is cleared if selecting last index and its removed, and more
* Changed surface_list/editor signal format to `object.signal.connect()` to take advantage of parser detection of signal misspellings. Strings don't check until called at runtime.

Originally the idea was to include a stable surface id, and a separate sortable ID, but it was getting very complicated and unwieldly. In the end this works. Surfaces can be reordered and edited much more seamlessly. And with #168 they are "usable" with color and the checkered pattern.


Fixes #146
Fixes #160 
Branched off of #168 so review that first and only look at the second commit here.
If you merge this instead of approving, merge 168 then use `Merge pull request: Rebase and merge` and make a merge commit.
