### PR TITLE
Warn about null textures breaking exported games

### DIFF
--- a/project/addons/terrain_3d/editor/editor.gd
+++ b/project/addons/terrain_3d/editor/editor.gd
@@ -21,6 +21,7 @@ var surface_list_container: CustomControlContainer = CONTAINER_INSPECTOR_BOTTOM
 var region_gizmo: RegionGizmo
 var current_region_position: Vector2
 var mouse_global_position: Vector3 = Vector3.ZERO
+var _warn_textures: bool = false
 
 
 func _enter_tree() -> void:
@@ -34,6 +35,7 @@ func _enter_tree() -> void:
 	surface_list.connect("resource_changed", _on_surface_list_resource_changed)
 	surface_list.connect("resource_inspected", _on_surface_list_resource_selected)
 	surface_list.connect("resource_selected", ui._on_setting_changed)
+	surface_list.connect("resource_null_texture", _on_surface_list_null_texture)
 	
 	region_gizmo = RegionGizmo.new()
 	
@@ -239,3 +241,9 @@ func _on_surface_list_visibility_changed() -> void:
 		if get_editor_interface().is_distraction_free_mode_enabled():
 			surface_list_container = CONTAINER_SPATIAL_EDITOR_SIDE_RIGHT
 		add_control_to_container(surface_list_container, surface_list)
+
+
+func _on_surface_list_null_texture(warn_textures: bool) -> void:
+	_warn_textures = warn_textures
+	terrain.update_configuration_warnings()
+

--- a/src/terrain_3d.cpp
+++ b/src/terrain_3d.cpp
@@ -662,6 +662,16 @@ Vector3 Terrain3D::get_intersection(Vector3 p_position, Vector3 p_direction) {
 	return Vector3(FLT_MAX, FLT_MAX, FLT_MAX);
 }
 
+PackedStringArray Terrain3D::_get_configuration_warnings() const {
+	PackedStringArray ret;
+	if (_plugin) {
+		if (_plugin->get("_warn_textures")) {
+			ret.push_back("At least one Surface has a missing texture. This will break exported games!");
+		}
+	}
+	return ret;
+}
+
 ///////////////////////////
 // Protected Functions
 ///////////////////////////

--- a/src/terrain_3d.h
+++ b/src/terrain_3d.h
@@ -139,6 +139,8 @@ public:
 	void update_aabbs();
 	Vector3 get_intersection(Vector3 p_position, Vector3 p_direction);
 
+	PackedStringArray _get_configuration_warnings() const;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/src/terrain_3d_storage.cpp
+++ b/src/terrain_3d_storage.cpp
@@ -145,8 +145,12 @@ void Terrain3DStorage::_update_surface_data(bool p_update_textures, bool p_updat
 				if (tex.is_null()) {
 					img = get_filled_image(albedo_size, COLOR_RB, true, Image::FORMAT_RGBA8);
 					img->compress_from_channels(Image::COMPRESS_S3TC, Image::USED_CHANNELS_RGBA);
+					LOG(DEBUG, "ID ", i, " albedo texture is null. Creating a new one. Format: ", img->get_format());
+					LOG(WARN, "ID ", i, " albedo texture is null. This will break exported games!");
+					// Waiting for Godot https://github.com/outobugi/Terrain3D/issues/164
 				} else {
 					img = tex->get_image();
+					LOG(DEBUG, "ID ", i, " albedo texture is valid. Format: ", img->get_format());
 				}
 
 				albedo_texture_array.push_back(img);
@@ -176,8 +180,12 @@ void Terrain3DStorage::_update_surface_data(bool p_update_textures, bool p_updat
 				if (tex.is_null()) {
 					img = get_filled_image(normal_size, COLOR_NORMAL, true, Image::FORMAT_RGBA8);
 					img->compress_from_channels(Image::COMPRESS_S3TC, Image::USED_CHANNELS_RGBA);
+					LOG(DEBUG, "ID ", i, " normal texture is null. Creating a new one. Format: ", img->get_format());
+					LOG(WARN, "ID ", i, " normal texture is null. This will break exported games!");
+					// Waiting for Godot https://github.com/outobugi/Terrain3D/issues/164
 				} else {
 					img = tex->get_image();
+					LOG(DEBUG, "ID ", i, " Normal texture is valid. Format: ", img->get_format());
 				}
 
 				normal_texture_array.push_back(img);


### PR DESCRIPTION
Any null textures in surfaces breaks exports. Releases crash, debugs turn textures white. This PR mitigates #164, for now.

This PR:
* Warns about null textures breaking exported games in the console
* Warns in the scenetree on the terrain3d node
* Triggers surface list updates (and warnings check) on every inspector change

