### PR TITLE
Store created texture blanks to enforce non-null textures

### DIFF
--- a/project/addons/terrain_3d/editor/components/surface_list.gd
+++ b/project/addons/terrain_3d/editor/components/surface_list.gd
@@ -146,16 +146,6 @@ class ListEntry extends VBoxContainer:
 					if texture:
 						draw_texture_rect(texture, rect, false)
 					modulate = resource.get_albedo()
-					
-					if !texture:
-						# Draw checker texture
-						var s: Vector2 = rect.size
-						var col_a: Color = Color(0.8, 0.8, 0.8)
-						var col_b: Color = Color(0.5, 0.5, 0.5)
-						draw_rect(Rect2(Vector2.ZERO, s/2), col_a)
-						draw_rect(Rect2(s/2, s/2), col_a)
-						draw_rect(Rect2(Vector2(s.x, 0) / 2, s/2), col_b)
-						draw_rect(Rect2(Vector2(0, s.y) / 2, s/2), col_b)
 				if drop_data:
 					draw_style_box(focus, rect)
 				if is_hovered:
@@ -210,14 +200,19 @@ class ListEntry extends VBoxContainer:
 			if text.is_empty():
 				text = "New Surface"
 			set_tooltip_text(text)
+			resource.value_changed.connect(_on_surface_changed)
+			resource.texture_changed.connect(_on_surface_changed)
 		
 		if button_close:
 			button_close.set_visible(resource != null)
 			
 		queue_redraw()
 		if !no_signal:
-			emit_signal("changed", res)
-			
+			emit_signal("changed", resource)
+
+	func _on_surface_changed() -> void:
+		emit_signal("changed", resource)
+
 	func set_selected(value: bool):
 		is_selected = value
 		queue_redraw()

--- a/src/terrain_3d_storage.h
+++ b/src/terrain_3d_storage.h
@@ -18,7 +18,7 @@ using namespace godot;
 #define COLOR_BLACK Color(0.0f, 0.0f, 0.0f, 1.0f)
 #define COLOR_WHITE Color(1.0f, 1.0f, 1.0f, 1.0f)
 #define COLOR_ROUGHNESS Color(1.0f, 1.0f, 1.0f, 0.5f)
-#define COLOR_RB Color(1.0f, 0.0f, 1.0f, 1.0f)
+#define COLOR_CHECKED Color(1.f, 1.f, 1.0f, -1.0f)
 #define COLOR_NORMAL Color(0.5f, 0.5f, 1.0f, 1.0f)
 
 class Terrain3DStorage : public Resource {

--- a/src/terrain_3d_surface.cpp
+++ b/src/terrain_3d_surface.cpp
@@ -10,7 +10,7 @@
 
 bool Terrain3DSurface::_texture_is_valid(const Ref<Texture2D> &p_texture) const {
 	if (p_texture.is_null()) {
-		LOG(ERROR, "Provided texture is null.");
+		LOG(DEBUG, "Provided texture is null.");
 		return true;
 	}
 


### PR DESCRIPTION
This PR:

* Enforces non-null textures in surfaces, creating a checkered blank if missing. Size is taken from previous textures or defaults to 1024. It's now not possible to create a null texture as Storage fills it in on update. 
* Triggers surface list updates on every inspector change, so albedo changes the icon

![image](https://github.com/outobugi/Terrain3D/assets/632766/2ece5761-2f67-4d14-8ce0-8a23edce0f2e)

Fixes #164 
If you merge this instead of approving, please use `Merge pull request: Rebase and merge` and make a merge commit.